### PR TITLE
Move `doctrine/orm` to suggest

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,10 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=5.5",
-        "psr/http-message": "^1.0",
-        "doctrine/orm": "^2.5"
+        "psr/http-message": "^1.0"
+    },
+    "suggest": {
+        "doctrine/orm": "Allow `DoctrineOrmProcessor` to be used"
     },
     "require-dev": {
         "zendframework/zend-diactoros": "^1.3",


### PR DESCRIPTION
This makes `doctrine/orm` not a hard-dependency. Because there could be several implementations of `ProcessorInterface`, making require dependencies for all of them is not a good idea. Also, this library could work without Doctrine if you implement another processor.

It could also be moved to `require-dev`. What do you think?
